### PR TITLE
React native support

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
   },
   "release": {
     "branch": "master"
+  },
+  "dependencies": {
+    "axios": "^0.18.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default;
+const axios = require('axios');
 const EventEmitter = require('events');
 const StreamReader = require('./StreamReader');
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-const http = require('http');
-const util = require('util');
+const axios = require('axios').default;
 const EventEmitter = require('events');
 const StreamReader = require('./StreamReader');
 
@@ -53,7 +52,7 @@ class RadioParser extends EventEmitter {
         this.emit('metadata', metadata);
       });
 
-      response.pipe(reader);
+      response.data.pipe(reader);
       this.emit('stream', reader);
     } else {
       this._destroyResponse(response);
@@ -81,15 +80,26 @@ class RadioParser extends EventEmitter {
    * @private
    */
   _makeRequest() {
-    const request = http.request(this.getConfig('url'));
+    axios.get(this.getConfig('url'), {
+      headers: {
+        'Icy-MetaData': '1',
+        'user-Agent': 'Mozilla'
+      },
+      responseType: 'stream'
+    }).then((response) => {
+      this._onRequestResponse.bind(this)(response);
+    }).catch((error) => {
+      console.error(error);
+    });
+    // const request = http.request(this.getConfig('url'));
 
-    request.setHeader('Icy-MetaData', '1');
-    request.setHeader('User-Agent', 'Mozilla');
-    request.once('response', this._onRequestResponse.bind(this));
-    request.once('error', this._onRequestError.bind(this));
-    request.end();
+    // request.setHeader('Icy-MetaData', '1');
+    // request.setHeader('User-Agent', 'Mozilla');
+    // request.once('response', this._onRequestResponse.bind(this));
+    // request.once('error', this._onRequestError.bind(this));
+    // request.end();
 
-    return this;
+    // return this;
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -91,15 +91,6 @@ class RadioParser extends EventEmitter {
     }).catch((error) => {
       console.error(error);
     });
-    // const request = http.request(this.getConfig('url'));
-
-    // request.setHeader('Icy-MetaData', '1');
-    // request.setHeader('User-Agent', 'Mozilla');
-    // request.once('response', this._onRequestResponse.bind(this));
-    // request.once('error', this._onRequestError.bind(this));
-    // request.end();
-
-    // return this;
   }
 
   /**


### PR DESCRIPTION
only nodejs have access to http module, but web, react-native and so on other javacript runtime enviroments don't have http module so this library won't work, but using axios library it runs http where it's available or fetch on react-native xhttprequest on web and so fork...